### PR TITLE
Tag Availability Zones

### DIFF
--- a/jobs/telegraf-system/templates/config/telegraf.conf.erb
+++ b/jobs/telegraf-system/templates/config/telegraf.conf.erb
@@ -2,6 +2,7 @@
   service = "<%= spec.deployment.sub(/-[0-9a-f]{20}$/, '') %>"
   node_type = "<%= spec.name %>"
   instance = "<%= spec.index %>"
+  az = "<%= spec.az %>"
   <% if_p("telegraf.tags") do |tags| tags.each do |tag, value| %>
   <%= tag %> = "<%= value %>"
   <% end; end %>


### PR DESCRIPTION
Add `az` tag to system metrics to improve visibility in deployments to multiple Availability Zones.