### PR TITLE
Exclude OvelayFS from disk stats

### DIFF
--- a/jobs/telegraf-system/templates/config/telegraf.conf.erb
+++ b/jobs/telegraf-system/templates/config/telegraf.conf.erb
@@ -21,7 +21,7 @@
   percpu = false
   totalcpu = true
 [[inputs.disk]]
-  ignore_fs = ["tmpfs", "devtmpfs", "none"]
+  ignore_fs = ["tmpfs", "devtmpfs", "none", "overlay"]
 [[inputs.diskio]]
   # individual partitions can be reported using "sda1" syntax
   devices = ["sda", "sdb", "sdc", "xvda", "xvdb", "xvdc"]


### PR DESCRIPTION
Docker nodes with OverlayFS has a large number of ephemeral file systems, which generates unnecessary metrics and increase cardinality. Go green - do not report those FS.