### PR TITLE
Updated README with remote release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
 # Telegraf release for BOSH
 
-## Deploy with BOSH add-on
+## Deploy with BOSH runtime-config
 
-* Upload release to BOSH director
+Update BOSH runtime config with telegraf job configuration as listed below
 
-        bosh upload-release https://github.com/Comcast/telegraf-boshrelease/releases/download/v7/c-telegraf-7.tgz
+```shell
+# review existing runtime config
+bosh runtime-config
+# merge with content listed below and save in file runtime-config.yml
+# upload updated runtime config
+bosh update-runtime-config runtime-config.yml
+```
 
-* Update BOSH runtime config with telegraf job configuration as listed below
+## `runtime-config.yml` file example
 
-        # review existing runtime config
-        bosh runtime-config
-        # merge with content listed below and save in file runtime-config.yml
-        # upload runtime config
-        bosh update-runtime-config runtime-config.yml
-
-## Example of `runtime-config.yml` file
-
-    releases:
-    - name: c-telegraf
-      version: 7
-    addons:
-    - name: c-telegraf
-      jobs:
-      - name: telegraf-system
-        release: c-telegraf
-      properties:
-        telegraf:
-          tags:
-            region: us-east-1
-          influxdb:
-            url: http://influxdb.example.com:8086
-            database: system
-            retention_policy: default
+```yaml
+releases:
+- name: c-telegraf
+  sha1: 416087f6f0477c41189674d8da393717d61f7be6
+  url: https://github.com/Comcast/telegraf-boshrelease/releases/download/v8/c-telegraf-8.tgz
+  version: 8
+addons:
+- name: c-telegraf
+  jobs:
+  - name: telegraf-system
+    release: c-telegraf
+  properties:
+    telegraf:
+      tags:
+        region: us-east-1
+      influxdb:
+        url: http://influxdb.example.com:8086
+        database: system
+        retention_policy: default
+```


### PR DESCRIPTION
Save a step - use remote upload-release. This change helps to deploy faster by eliminating unnecessary download step and more securely by providing SHA checksum of the release artifact.

Also, updated README with the most current release v8.