### PR TITLE
Limit file systems to report

### DIFF
--- a/jobs/telegraf-system/templates/config/telegraf.conf.erb
+++ b/jobs/telegraf-system/templates/config/telegraf.conf.erb
@@ -21,7 +21,8 @@
   percpu = false
   totalcpu = true
 [[inputs.disk]]
-  ignore_fs = ["tmpfs", "devtmpfs", "none", "overlay"]
+  # Limit to BOSH specific mount points
+  mount_points = ["/", "/var/vcap/data", "/var/vcap/store"]
 [[inputs.diskio]]
   # individual partitions can be reported using "sda1" syntax
   devices = ["sda", "sdb", "sdc", "xvda", "xvdb", "xvdc"]


### PR DESCRIPTION
Restrict telegraf to report only real file systems:
- root
- ephemeral
- persistent